### PR TITLE
Add filter for the args sent to wp_get_sites()

### DIFF
--- a/network-plugin-auditor.php
+++ b/network-plugin-auditor.php
@@ -298,6 +298,8 @@ class NetworkPluginAuditor {
         $args = array(
             'limit'  => 10000 // use the wp_is_large_network upper limit
         );
+        
+        $args = apply_filters( 'npa_get_network_blog_list_args', $args );
 
         if ( function_exists( 'wp_get_sites' ) && function_exists( 'wp_is_large_network' ) ) {
             // If wp_is_large_network() returns TRUE, wp_get_sites() will return an empty array.


### PR DESCRIPTION
This will allow for a bit more flexibility in the use of this plugin. Multi-network users can set $args['network_id'] to null to get all sites -- currently the plugin is a bit difficult to use if you have a lot of networks, because you have to visit each network admin separately. Others may also want to ignore some blogs or set other args in wp_get_sites()
